### PR TITLE
Simplify illimited number of steps to main after and before

### DIFF
--- a/baldrick-broth.yaml
+++ b/baldrick-broth.yaml
@@ -44,37 +44,34 @@ workflows:
     tasks:
       jest:
         title: Run the unit tests with Jest
-        description: Use the Jest framework to run unit test (deprecated)
+        description: Use the Jest framework to run unit test (deprecated)  
+        links:
+          - title: Jest is a JavaScript Testing Framework
+            url: https://jestjs.io/
         steps:
-          - a: batch
-            title: Run Jest unit tests
-            links:
-              - title: Jest is a JavaScript Testing Framework
-                url: https://jestjs.io/
-            commands:
+          - commands:
               - title: Test all test files in test folder
                 run: npx baldrick-dev-ts test check
       spec:
         title: Run unit tests declaratively
         description: Run unit tests for pure functions declaratively using YAML files
         motivation: Check that the units of code behave as intended
+        links:
+          - title: Baldrick Zest run tests declaratively
+            url: https://github.com/flarebyte/baldrick-zest-engine
         steps:
-          - a: batch
-            title: Run the baldrick-zest unit tests
-            links:
-              - title: Baldrick Zest run tests declaratively
-                url: https://github.com/flarebyte/baldrick-zest-engine
-            commands:
+          - commands:
               - title: Run all baldrick zest files
                 run: node --loader ts-node/esm .baldrick-zest.ts
       pest:
         title: Run acceptance tests for the CLI
         description: Run acceptance tests declaratively using YAML files
         motivation: Check that the CLI application behaves as intended
+        links:
+          - title: Testing with baldrick-pest
+            url: https://github.com/flarebyte/baldrick-pest
         steps:
-          - a: batch
-            title: Retrieve a list of acceptance tests
-            commands:
+          - commands:
               - name: pest-files
                 title: List pest yaml files
                 run: scc pest-spec --include-ext yaml --by-file --format csv
@@ -82,12 +79,7 @@ workflows:
                   - save
                   - csv
                   - silent
-          - a: batch
-            title: Run the baldrick-pest acceptance tests
-            links:
-              - title: Testing with baldrick-pest
-                url: https://github.com/flarebyte/baldrick-pest
-            each:
+          - each:
               - name: pest-file
                 values: data.test::pest::pest-files
             commands:
@@ -100,9 +92,7 @@ workflows:
         motivation: Simulate a CLI app in development without the need to install it
           globally
         steps:
-          - a: batch
-            title: Run the CLI using ts-node
-            commands:
+          - commands:
               - title: Run the CLI locally
                 run: node --loader ts-node/esm src/cli.mts
   transpile:
@@ -113,13 +103,11 @@ workflows:
         title: Transpile typescript
         description: Generate javascript from the typescript source code
         motivation: Javascript code is more portable and can be consumed by other projects
+        links:
+          - title: tsc compiles typescript defined by a tsconfig.json
+            url: https://www.typescriptlang.org/docs/handbook/compiler-options.html
         steps:
-          - a: batch
-            title: Compile the typescript code
-            links:
-              - title: tsc compiles typescript defined by a tsconfig.json
-                url: https://www.typescriptlang.org/docs/handbook/compiler-options.html
-            commands:
+          - commands:
               - title: Delete dist folder
                 run: rm -rf dist
               - title: Compile with typescript
@@ -133,9 +121,7 @@ workflows:
         description: Upgrade to latest npm dependencies
         motivation: Keep up with security and improvements
         steps:
-          - a: batch
-            title: Upgrade npm dependencies
-            commands:
+          - commands:
               - title: Upgrade to latest dependencies
                 run: yarn upgrade --latest
               - title: Display advice about yarn upgrade-interactive
@@ -149,9 +135,7 @@ workflows:
         description: Generate the markdown documentation for the typescript project
         motivation: Good documentation is essential for developer experience
         steps:
-          - a: batch
-            title: Generate the documentation
-            commands:
+          - commands:
               - name: report-folder
                 title: Ensure that we have a report folder
                 run: mdir -p report
@@ -188,9 +172,7 @@ workflows:
         description: Enable useful features for the github project repository
         motivation: Create consistent settings
         steps:
-          - a: batch
-            title: Standardize repository settings
-            commands:
+          - commands:
               - name: edit
                 title: Configure usual settings for github project
                 run: gh repo edit --delete-branch-on-merge --enable-squash-merge
@@ -203,9 +185,7 @@ workflows:
         description: Find problems in Typescript code
         motivation: Make the code more consistent and avoid bugs
         steps:
-          - a: batch
-            title: Lint check
-            commands:
+          - commands:
               - name: check
                 title: Lint check sources
                 run: npx baldrick-dev-ts@latest lint check -s src test
@@ -214,9 +194,7 @@ workflows:
         description: Fix problems in Typescript code
         motivation: Facilitate routine maintenance of code
         steps:
-          - a: batch
-            title: Lint fix
-            commands:
+          - commands:
               - name: fix
                 title: Fix source code
                 run: npx baldrick-dev-ts@latest lint fix -s src test
@@ -229,9 +207,7 @@ workflows:
         description: Checks that the markdown documents follows some consistent guidelines
         motivation: Make the markdown documents consistent in style
         steps:
-          - a: batch
-            title: Check markdown
-            commands:
+          - commands:
               - name: check
                 title: Check markdown files
                 run: baldrick markdown check
@@ -244,9 +220,7 @@ workflows:
           guidelines
         motivation: Make the markdown documents consistent in style
         steps:
-          - a: batch
-            title: Fix Markdown all files
-            commands:
+          - commands:
               - title: Fix markdown files
                 run: npx baldrick-dev-ts@latest markdown fix
               - title: Fix markdown files in github
@@ -260,9 +234,7 @@ workflows:
           published
         motivation: Detect quality flaws before pushing the code
         steps:
-          - a: batch
-            title: Check if ready for publishing
-            commands:
+          - commands:
               - name: release-check
                 title: Checks that the version has been incremented
                 run: npx baldrick-dev-ts@latest release check
@@ -289,9 +261,7 @@ workflows:
         description: Gets the latest version of this configuration file
         motivation: Always apply the latest project conventions
         steps:
-          - a: batch
-            title: Upgrade baldrick-broth
-            commands:
+          - commands:
               - title: Remove previous temporary directory
                 run: rm -rf temp/broth
               - title: Create temporary directory
@@ -317,9 +287,7 @@ workflows:
           typescript projects
         motivation: Make the project structure consistent and easier to navigate
         steps:
-          - a: batch
-            title: github
-            commands:
+          - commands:
               - title: Create all github repositories
                 run: mkdir -p .github/workflows .github/ISSUE_TEMPLATE
               - title: Github - create bug report form
@@ -336,9 +304,7 @@ workflows:
                 run: npx baldrick-whisker@latest render baldrick-broth.yaml
                   github:flarebyte:baldrick-reserve:template/ts/pull-request-template.hbs
                   .github/pull_request_template.md
-          - a: batch
-            title: configuration
-            commands:
+          - commands:
               - title: Create all needed repositories
                 run: mkdir -p .vscode src test spec script script/data script/schema
               - title: Install default vscode snippets
@@ -372,9 +338,7 @@ workflows:
               - title: Create .remarkrc.yml
                 run: npx baldrick-whisker@latest object .remarkrc.yml
                   github:flarebyte:baldrick-reserve:data/ts/remarkrc.yml
-          - a: batch
-            title: markdown
-            commands:
+          - commands:
               - title: Create CONTRIBUTING.md with contribution guidelines
                 run: npx baldrick-whisker@latest render baldrick-broth.yaml
                   github:flarebyte:baldrick-reserve:template/ts/contributing.hbs
@@ -406,9 +370,7 @@ workflows:
                   LICENSE.md
               - title: Fix markdown
                 run: npx baldrick-broth@latest md fix
-          - a: batch
-            title: precedent
-            commands:
+          - commands:
               - name: package-json
                 title: Backup dependencies
                 run: cat package.json
@@ -416,9 +378,7 @@ workflows:
                   - save
                   - silent
                   - json
-          - a: batch
-            title: package
-            commands:
+          - commands:
               - a: mask-object
                 title: Extracts dependencies from package.json
                 name: package-json-deps
@@ -441,9 +401,7 @@ workflows:
           typescript projects
         motivation: Make the project structure consistent and easier to navigate
         steps:
-          - a: batch
-            title: packaging
-            commands:
+          - commands:
               - name: package-json
                 title: Backup dependencies
                 run: cat package.json

--- a/baldrick-broth.yaml
+++ b/baldrick-broth.yaml
@@ -3,7 +3,7 @@ model:
     title: Build automation tool and task runner
     description: Take your developer workflow to the next level with a custom CLI
       with relevant documentation for running your task
-    version: 0.9.0
+    version: 0.10.0
     keywords:
       - CLI
       - Task runner

--- a/baldrick-broth.yaml
+++ b/baldrick-broth.yaml
@@ -48,8 +48,8 @@ workflows:
         links:
           - title: Jest is a JavaScript Testing Framework
             url: https://jestjs.io/
-        steps:
-          - commands:
+        main:
+          commands:
               - title: Test all test files in test folder
                 run: npx baldrick-dev-ts test check
       spec:
@@ -59,8 +59,8 @@ workflows:
         links:
           - title: Baldrick Zest run tests declaratively
             url: https://github.com/flarebyte/baldrick-zest-engine
-        steps:
-          - commands:
+        main:
+          commands:
               - title: Run all baldrick zest files
                 run: node --loader ts-node/esm .baldrick-zest.ts
       pest:
@@ -70,8 +70,8 @@ workflows:
         links:
           - title: Testing with baldrick-pest
             url: https://github.com/flarebyte/baldrick-pest
-        steps:
-          - commands:
+        before:
+          commands:
               - name: pest-files
                 title: List pest yaml files
                 run: scc pest-spec --include-ext yaml --by-file --format csv
@@ -79,10 +79,11 @@ workflows:
                   - save
                   - csv
                   - silent
-          - each:
+        main:
+          each:
               - name: pest-file
                 values: data.test::pest::pest-files
-            commands:
+          commands:
               - title: Run regression on file
                 name: Run regression on {{pest-file.Location}}
                 run: npx baldrick-pest@latest test --spec-file {{pest-file.Location}}
@@ -91,8 +92,8 @@ workflows:
         description: Run the client with ts-node during development
         motivation: Simulate a CLI app in development without the need to install it
           globally
-        steps:
-          - commands:
+        main:
+          commands:
               - title: Run the CLI locally
                 run: node --loader ts-node/esm src/cli.mts
   transpile:
@@ -106,8 +107,8 @@ workflows:
         links:
           - title: tsc compiles typescript defined by a tsconfig.json
             url: https://www.typescriptlang.org/docs/handbook/compiler-options.html
-        steps:
-          - commands:
+        main:
+          commands:
               - title: Delete dist folder
                 run: rm -rf dist
               - title: Compile with typescript
@@ -120,8 +121,8 @@ workflows:
         title: Upgrade to latest dependencies
         description: Upgrade to latest npm dependencies
         motivation: Keep up with security and improvements
-        steps:
-          - commands:
+        main:
+          commands:
               - title: Upgrade to latest dependencies
                 run: yarn upgrade --latest
               - title: Display advice about yarn upgrade-interactive
@@ -134,8 +135,8 @@ workflows:
         title: Generate documentation
         description: Generate the markdown documentation for the typescript project
         motivation: Good documentation is essential for developer experience
-        steps:
-          - commands:
+        main:
+          commands:
               - name: report-folder
                 title: Ensure that we have a report folder
                 run: mdir -p report
@@ -171,8 +172,8 @@ workflows:
         title: Standardize the github repository
         description: Enable useful features for the github project repository
         motivation: Create consistent settings
-        steps:
-          - commands:
+        main:
+          commands:
               - name: edit
                 title: Configure usual settings for github project
                 run: gh repo edit --delete-branch-on-merge --enable-squash-merge
@@ -184,8 +185,8 @@ workflows:
         title: Static code analysis of Typescript code
         description: Find problems in Typescript code
         motivation: Make the code more consistent and avoid bugs
-        steps:
-          - commands:
+        main:
+          commands:
               - name: check
                 title: Lint check sources
                 run: npx baldrick-dev-ts@latest lint check -s src test
@@ -193,8 +194,8 @@ workflows:
         title: Fix static code analysis
         description: Fix problems in Typescript code
         motivation: Facilitate routine maintenance of code
-        steps:
-          - commands:
+        main:
+          commands:
               - name: fix
                 title: Fix source code
                 run: npx baldrick-dev-ts@latest lint fix -s src test
@@ -206,8 +207,8 @@ workflows:
         title: Check Markdown files
         description: Checks that the markdown documents follows some consistent guidelines
         motivation: Make the markdown documents consistent in style
-        steps:
-          - commands:
+        main:
+          commands:
               - name: check
                 title: Check markdown files
                 run: baldrick markdown check
@@ -219,8 +220,8 @@ workflows:
         description: Modify the markdown documents to ensure they follow some consistent
           guidelines
         motivation: Make the markdown documents consistent in style
-        steps:
-          - commands:
+        main:
+          commands:
               - title: Fix markdown files
                 run: npx baldrick-dev-ts@latest markdown fix
               - title: Fix markdown files in github
@@ -233,8 +234,8 @@ workflows:
         description: Run a sequence of commands to check that the library is ready to be
           published
         motivation: Detect quality flaws before pushing the code
-        steps:
-          - commands:
+        main:
+          commands:
               - name: release-check
                 title: Checks that the version has been incremented
                 run: npx baldrick-dev-ts@latest release check
@@ -260,8 +261,8 @@ workflows:
         title: Upgrade baldrick-broth configuration to latest version
         description: Gets the latest version of this configuration file
         motivation: Always apply the latest project conventions
-        steps:
-          - commands:
+        main:
+          commands:
               - title: Remove previous temporary directory
                 run: rm -rf temp/broth
               - title: Create temporary directory
@@ -286,8 +287,8 @@ workflows:
         description: Normalize the project in a similar fashion that the other
           typescript projects
         motivation: Make the project structure consistent and easier to navigate
-        steps:
-          - commands:
+        main:
+          commands:
               - title: Create all github repositories
                 run: mkdir -p .github/workflows .github/ISSUE_TEMPLATE
               - title: Github - create bug report form
@@ -304,7 +305,6 @@ workflows:
                 run: npx baldrick-whisker@latest render baldrick-broth.yaml
                   github:flarebyte:baldrick-reserve:template/ts/pull-request-template.hbs
                   .github/pull_request_template.md
-          - commands:
               - title: Create all needed repositories
                 run: mkdir -p .vscode src test spec script script/data script/schema
               - title: Install default vscode snippets
@@ -338,7 +338,6 @@ workflows:
               - title: Create .remarkrc.yml
                 run: npx baldrick-whisker@latest object .remarkrc.yml
                   github:flarebyte:baldrick-reserve:data/ts/remarkrc.yml
-          - commands:
               - title: Create CONTRIBUTING.md with contribution guidelines
                 run: npx baldrick-whisker@latest render baldrick-broth.yaml
                   github:flarebyte:baldrick-reserve:template/ts/contributing.hbs
@@ -370,7 +369,6 @@ workflows:
                   LICENSE.md
               - title: Fix markdown
                 run: npx baldrick-broth@latest md fix
-          - commands:
               - name: package-json
                 title: Backup dependencies
                 run: cat package.json
@@ -378,7 +376,6 @@ workflows:
                   - save
                   - silent
                   - json
-          - commands:
               - a: mask-object
                 title: Extracts dependencies from package.json
                 name: package-json-deps
@@ -400,8 +397,8 @@ workflows:
         description: Normalize the project in a similar fashion that the other
           typescript projects
         motivation: Make the project structure consistent and easier to navigate
-        steps:
-          - commands:
+        main:
+          commands:
               - name: package-json
                 title: Backup dependencies
                 run: cat package.json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baldrick-broth",
   "description": "Build automation tool and task runner",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "Olivier Huin",
     "url": "https://github.com/olih"

--- a/pest-spec/snapshots/cli--test-spec--spec.txt
+++ b/pest-spec/snapshots/cli--test-spec--spec.txt
@@ -1,20 +1,21 @@
 [2K[1G[2m$ node --loader ts-node/esm src/cli.mts test spec[22m
-✓ baldrick-broth is done. Version 0.9.0
-[STARTED] main step
+✓ baldrick-broth is done. Version 0.10.0
+[STARTED] Main
 [STARTED] Run all baldrick zest files
 [DATA] node --loader ts-node/esm .baldrick-zest.ts
 [TITLE] run-all-baldrick-zest-files
 [DATA] OK
 [SUCCESS] run-all-baldrick-zest-files
-[SUCCESS] main step
+[SUCCESS] Main
 
 
-(node:21746) ExperimentalWarning: Custom ESM Loaders is an experimental feature. This feature could change at any time
+getDataProperty: Invalid path data.g.get-property: g then undefined  [38;2;75;0;130m◼ Run all baldrick zest files[39m
+(node:25460) ExperimentalWarning: Custom ESM Loaders is an experimental feature. This feature could change at any time
 (Use `node --trace-warnings ...` to show where the warning was created)
 [1m⦿ Function basicCommandsExecution[22m [90m./src/basic-execution.ts | spec/basic-execution/basic-execution.zest.yaml[39m
   [32m✓ PASS[39m [1msome basic execution on the context[22m   [90m📷 spec/snapshots/basic-execution/basic-execution--basic.yaml[39m
 [1m⦿ Function getSchema[22m [90m./src/build-model.ts | spec/build-model/get-schema.zest.yaml[39m
   [32m✓ PASS[39m [1mProduce a JSON schema[22m   [90m📷 spec/snapshots/build-model/get-schema--schema.json[39m
 [1m⦿ Function safeParseBuild[22m [90m./src/build-model.ts | spec/build-model/safe-parse-build.zest.yaml[39m
-  [32m✓ PASS[39m [1mTest edge cases that will produce errors[22m   [90m📷 spec/snapshots/build-model/safe-parse-build--invalid-too-large.yaml[39m
   [32m✓ PASS[39m [1mabstract with object crumble[22m   [90m📷 spec/snapshots/build-model/safe-parse-build--abstract-parsing.yaml[39m
+  [32m✓ PASS[39m [1mTest edge cases that will produce errors[22m   [90m📷 spec/snapshots/build-model/safe-parse-build--invalid-too-large.yaml[39m

--- a/pest-spec/snapshots/cli--test-spec--spec.txt
+++ b/pest-spec/snapshots/cli--test-spec--spec.txt
@@ -1,16 +1,17 @@
+yarn run v1.22.19
 $ node --loader ts-node/esm src/cli.mts test spec
 ✓ baldrick-broth is done. Version 0.9.0
-[STARTED] Run the baldrick-zest unit tests
+[STARTED] main step
 [STARTED] Run all baldrick zest files
 [DATA] node --loader ts-node/esm .baldrick-zest.ts
 [TITLE] run-all-baldrick-zest-files
 [DATA] OK
 [SUCCESS] run-all-baldrick-zest-files
-[SUCCESS] Run the baldrick-zest unit tests
+[SUCCESS] main step
 
 
-Run the baldrick-zest unit tests:
----------------------------------
-⦿ Function basicExecution ./src/basic-execution.ts | spec/basic-execution/basic-execution.zest.yaml
 ⦿ Function getSchema ./src/build-model.ts | spec/build-model/get-schema.zest.yaml
 ⦿ Function safeParseBuild ./src/build-model.ts | spec/build-model/safe-parse-build.zest.yaml
+⦿ Function basicCommandsExecution ./src/basic-execution.ts | spec/basic-execution/basic-execution.zest.yaml
+
+Done in 2.77s.

--- a/pest-spec/snapshots/cli--test-spec--spec.txt
+++ b/pest-spec/snapshots/cli--test-spec--spec.txt
@@ -1,5 +1,4 @@
-yarn run v1.22.19
-$ node --loader ts-node/esm src/cli.mts test spec
+[2K[1G[2m$ node --loader ts-node/esm src/cli.mts test spec[22m
 ✓ baldrick-broth is done. Version 0.9.0
 [STARTED] main step
 [STARTED] Run all baldrick zest files
@@ -10,8 +9,12 @@ $ node --loader ts-node/esm src/cli.mts test spec
 [SUCCESS] main step
 
 
-⦿ Function getSchema ./src/build-model.ts | spec/build-model/get-schema.zest.yaml
-⦿ Function safeParseBuild ./src/build-model.ts | spec/build-model/safe-parse-build.zest.yaml
-⦿ Function basicCommandsExecution ./src/basic-execution.ts | spec/basic-execution/basic-execution.zest.yaml
-
-Done in 2.77s.
+(node:21746) ExperimentalWarning: Custom ESM Loaders is an experimental feature. This feature could change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+[1m⦿ Function basicCommandsExecution[22m [90m./src/basic-execution.ts | spec/basic-execution/basic-execution.zest.yaml[39m
+  [32m✓ PASS[39m [1msome basic execution on the context[22m   [90m📷 spec/snapshots/basic-execution/basic-execution--basic.yaml[39m
+[1m⦿ Function getSchema[22m [90m./src/build-model.ts | spec/build-model/get-schema.zest.yaml[39m
+  [32m✓ PASS[39m [1mProduce a JSON schema[22m   [90m📷 spec/snapshots/build-model/get-schema--schema.json[39m
+[1m⦿ Function safeParseBuild[22m [90m./src/build-model.ts | spec/build-model/safe-parse-build.zest.yaml[39m
+  [32m✓ PASS[39m [1mTest edge cases that will produce errors[22m   [90m📷 spec/snapshots/build-model/safe-parse-build--invalid-too-large.yaml[39m
+  [32m✓ PASS[39m [1mabstract with object crumble[22m   [90m📷 spec/snapshots/build-model/safe-parse-build--abstract-parsing.yaml[39m

--- a/pest-spec/snapshots/cli-help--command-help--spec-help.txt
+++ b/pest-spec/snapshots/cli-help--command-help--spec-help.txt
@@ -1,9 +1,9 @@
-$ node --loader ts-node/esm src/cli.mts test spec --help
+[2K[1G[2m$ node --loader ts-node/esm src/cli.mts test spec --help[22m
 Usage: baldrick-broth test spec [options]
 
 Run unit tests for pure functions declaratively using YAML files
 
-Motivation: Check that the units of code behave as intended
+[90mMotivation: Check that the units of code behave as intended[39m
 
 Options:
   -h, --help  display help for command

--- a/pest-spec/snapshots/cli-help--general-help--help.txt
+++ b/pest-spec/snapshots/cli-help--general-help--help.txt
@@ -1,4 +1,4 @@
-$ node --loader ts-node/esm src/cli.mts --help
+[2K[1G[2m$ node --loader ts-node/esm src/cli.mts --help[22m
 Usage: baldrick-broth [options] [command]
 
 CLI for build automation and running tasks

--- a/spec/fixtures/build.yaml
+++ b/spec/fixtures/build.yaml
@@ -33,9 +33,7 @@ workflows:
           - description: only run this
             flags: '-p, --pizza-type <type>'
         steps:
-          - a: batch
-            title: Run calculate shell step
-            commands:
+          - commands:
               - a: get-property
                 name: githubAccount
                 title: Set variable githubAccount
@@ -50,9 +48,7 @@ workflows:
                 onFailure:
                   - exit
         finally:
-          - a: batch
-            title: Run finish shell step
-            commands:
+          - commands:
               - run: >-
                   cat {{whisker}} render {{project_yaml}} {{generate_hbs}}
                   {{generate_sh}} {{color}}

--- a/spec/fixtures/build.yaml
+++ b/spec/fixtures/build.yaml
@@ -32,8 +32,8 @@ workflows:
         parameters:
           - description: only run this
             flags: '-p, --pizza-type <type>'
-        steps:
-          - commands:
+        main:
+          commands:
               - a: get-property
                 name: githubAccount
                 title: Set variable githubAccount
@@ -48,7 +48,7 @@ workflows:
                 onFailure:
                   - exit
         finally:
-          - commands:
+          commands:
               - run: >-
                   cat {{whisker}} render {{project_yaml}} {{generate_hbs}}
                   {{generate_sh}} {{color}}

--- a/spec/fixtures/build.yaml
+++ b/spec/fixtures/build.yaml
@@ -47,7 +47,7 @@ workflows:
                   - trim
                 onFailure:
                   - exit
-        finally:
+        after:
           commands:
               - run: >-
                   cat {{whisker}} render {{project_yaml}} {{generate_hbs}}

--- a/spec/fixtures/context.yaml
+++ b/spec/fixtures/context.yaml
@@ -48,7 +48,7 @@ build:
                     - trim
                   onFailure:
                     - exit
-          finally:
+          after:
             commands:
                 - run: >-
                     cat {{whisker}} render {{project_yaml}} {{generate_hbs}}
@@ -82,7 +82,7 @@ task:
             - trim
           onFailure:
             - exit
-  finally:
+  after:
     commands:
         - run: >-
             cat {{whisker}} render {{project_yaml}} {{generate_hbs}}

--- a/spec/fixtures/context.yaml
+++ b/spec/fixtures/context.yaml
@@ -34,9 +34,7 @@ build:
             - description: only run this
               flags: '-p, --pizza-type <type>'
           steps:
-            - a: batch
-              title: Run calculate shell step
-              commands:
+            - commands:
                 - a: get-property
                   name: githubAccount
                   title: Set variable githubAccount
@@ -51,10 +49,7 @@ build:
                   onFailure:
                     - exit
           finally:
-            - a: batch
-              name: finish
-              title: Run finish shell step
-              commands:
+            - commands:
                 - run: >-
                     cat {{whisker}} render {{project_yaml}} {{generate_hbs}}
                     {{generate_sh}} {{color}}
@@ -73,9 +68,7 @@ task:
     - description: only run this
       flags: '-p, --pizza-type <type>'
   steps:
-    - a: batch
-      title: Run calculate shell step
-      commands:
+    - commands:
         - a: get-property
           name: githubAccount
           title: Set variable githubAccount
@@ -90,10 +83,7 @@ task:
           onFailure:
             - exit
   finally:
-    - a: batch
-      name: finish
-      title: Run finish shell step
-      commands:
+    - commands:
         - run: >-
             cat {{whisker}} render {{project_yaml}} {{generate_hbs}}
             {{generate_sh}} {{color}}

--- a/spec/fixtures/context.yaml
+++ b/spec/fixtures/context.yaml
@@ -33,8 +33,8 @@ build:
           parameters:
             - description: only run this
               flags: '-p, --pizza-type <type>'
-          steps:
-            - commands:
+          main:
+            commands:
                 - a: get-property
                   name: githubAccount
                   title: Set variable githubAccount
@@ -49,7 +49,7 @@ build:
                   onFailure:
                     - exit
           finally:
-            - commands:
+            commands:
                 - run: >-
                     cat {{whisker}} render {{project_yaml}} {{generate_hbs}}
                     {{generate_sh}} {{color}}
@@ -67,8 +67,8 @@ task:
   parameters:
     - description: only run this
       flags: '-p, --pizza-type <type>'
-  steps:
-    - commands:
+  main:
+    commands:
         - a: get-property
           name: githubAccount
           title: Set variable githubAccount
@@ -83,7 +83,7 @@ task:
           onFailure:
             - exit
   finally:
-    - commands:
+    commands:
         - run: >-
             cat {{whisker}} render {{project_yaml}} {{generate_hbs}}
             {{generate_sh}} {{color}}

--- a/spec/snapshots/build-model/get-schema--schema.json
+++ b/spec/snapshots/build-model/get-schema--schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "$ref": "#/definitions/baldrick-broth-schema",
   "definitions": {
     "baldrick-broth-schema": {
@@ -110,6 +109,30 @@
                       "maxLength": 300,
                       "description": "The main reason why this section of script is needed"
                     },
+                    "links": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri",
+                            "maxLength": 300,
+                            "description": "A https link to a webpage"
+                          }
+                        },
+                        "required": [
+                          "title",
+                          "url"
+                        ],
+                        "additionalProperties": false,
+                        "description": "Info about a link"
+                      },
+                      "description": "A list of useful links"
+                    },
                     "parameters": {
                       "type": "array",
                       "items": {
@@ -143,49 +166,14 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "a": {
-                            "type": "string",
-                            "const": "batch"
-                          },
                           "name": {
                             "type": "string",
-                            "minLength": 1,
-                            "maxLength": 60,
-                            "pattern": "[a-z][\\d_a-z]+",
-                            "description": "A short name that could be used a key or variable"
-                          },
-                          "title": {
-                            "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                          },
-                          "description": {
-                            "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/description"
-                          },
-                          "motivation": {
-                            "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/motivation"
-                          },
-                          "links": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "title": {
-                                  "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                                },
-                                "url": {
-                                  "type": "string",
-                                  "format": "uri",
-                                  "maxLength": 300,
-                                  "description": "A https link to a webpage"
-                                }
-                              },
-                              "required": [
-                                "title",
-                                "url"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Info about a link"
-                            },
-                            "description": "A list of useful links"
+                            "enum": [
+                              "main",
+                              "before",
+                              "after"
+                            ],
+                            "default": "main"
                           },
                           "if": {
                             "type": "string",
@@ -223,18 +211,6 @@
                             "maxItems": 3,
                             "description": "The same batch will be run multiple times for each loop"
                           },
-                          "onFinish": {
-                            "type": "array",
-                            "items": {
-                              "type": "string",
-                              "enum": [
-                                "exit",
-                                "silent"
-                              ]
-                            },
-                            "minItems": 1,
-                            "description": "Expected behavior when the batch finishes"
-                          },
                           "commands": {
                             "type": "array",
                             "items": {
@@ -265,7 +241,7 @@
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/motivation"
                                         },
                                         "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/links"
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                         },
                                         "value": {
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
@@ -300,7 +276,7 @@
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
                                         },
                                         "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/links"
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                         },
                                         "value": {
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
@@ -385,7 +361,7 @@
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
                                         },
                                         "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/links"
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                         },
                                         "values": {
                                           "type": "array",
@@ -425,7 +401,7 @@
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
                                         },
                                         "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/links"
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                         },
                                         "separator": {
                                           "type": "string",
@@ -467,7 +443,7 @@
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
                                         },
                                         "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/links"
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                         },
                                         "values": {
                                           "type": "array",
@@ -507,7 +483,7 @@
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
                                         },
                                         "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/links"
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                         },
                                         "values": {
                                           "type": "array",
@@ -547,7 +523,7 @@
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
                                         },
                                         "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/links"
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                         },
                                         "values": {
                                           "type": "array",
@@ -587,7 +563,7 @@
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
                                         },
                                         "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/links"
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                         },
                                         "values": {
                                           "type": "array",
@@ -627,7 +603,7 @@
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
                                         },
                                         "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/links"
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                         },
                                         "value": {
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
@@ -662,7 +638,7 @@
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
                                         },
                                         "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/links"
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                         },
                                         "start": {
                                           "type": "integer",
@@ -708,7 +684,7 @@
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
                                         },
                                         "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/links"
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                         },
                                         "value": {
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
@@ -743,7 +719,7 @@
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
                                         },
                                         "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/links"
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                         },
                                         "value": {
                                           "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
@@ -771,19 +747,23 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/name"
+                                      "type": "string",
+                                      "minLength": 1,
+                                      "maxLength": 60,
+                                      "pattern": "[a-z][\\d_a-z]+",
+                                      "description": "A short name that could be used a key or variable"
                                     },
                                     "title": {
                                       "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
                                     },
                                     "description": {
-                                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/description"
+                                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/description"
                                     },
                                     "motivation": {
-                                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/motivation"
+                                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/motivation"
                                     },
                                     "links": {
-                                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/links"
+                                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                     },
                                     "a": {
                                       "type": "string",
@@ -853,8 +833,6 @@
                           }
                         },
                         "required": [
-                          "a",
-                          "title",
                           "commands"
                         ],
                         "additionalProperties": false,
@@ -901,5 +879,6 @@
       "additionalProperties": false,
       "description": "Settings for a baldrick-broth file"
     }
-  }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/spec/snapshots/build-model/get-schema--schema.json
+++ b/spec/snapshots/build-model/get-schema--schema.json
@@ -842,9 +842,6 @@
                     },
                     "after": {
                       "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main"
-                    },
-                    "finally": {
-                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main"
                     }
                   },
                   "required": [

--- a/spec/snapshots/build-model/get-schema--schema.json
+++ b/spec/snapshots/build-model/get-schema--schema.json
@@ -161,692 +161,695 @@
                       },
                       "maxItems": 20
                     },
-                    "steps": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "enum": [
-                              "main",
-                              "before",
-                              "after"
-                            ],
-                            "default": "main"
-                          },
-                          "if": {
-                            "type": "string",
-                            "minLength": 1,
-                            "maxLength": 300,
-                            "pattern": "(([\\d._a-z]+)|(\\[\\d+]))+",
-                            "description": "A condition that must be satisfied to enable the batch"
-                          },
-                          "each": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "minLength": 1,
-                                  "maxLength": 60,
-                                  "pattern": "[a-z][\\d_a-z]+",
-                                  "description": "A short name that can used as variable"
-                                },
-                                "values": {
-                                  "type": "string",
-                                  "minLength": 1,
-                                  "maxLength": 300
-                                }
+                    "main": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "enum": [
+                            "unknown",
+                            "main",
+                            "before",
+                            "after"
+                          ],
+                          "default": "unknown"
+                        },
+                        "if": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 300,
+                          "pattern": "(([\\d._a-z]+)|(\\[\\d+]))+",
+                          "description": "A condition that must be satisfied to enable the batch"
+                        },
+                        "each": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 60,
+                                "pattern": "[a-z][\\d_a-z]+",
+                                "description": "A short name that can used as variable"
                               },
-                              "required": [
-                                "name",
-                                "values"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Configuration of every loop"
+                              "values": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 300
+                              }
                             },
-                            "minItems": 1,
-                            "maxItems": 3,
-                            "description": "The same batch will be run multiple times for each loop"
+                            "required": [
+                              "name",
+                              "values"
+                            ],
+                            "additionalProperties": false,
+                            "description": "Configuration of every loop"
                           },
-                          "commands": {
-                            "type": "array",
-                            "items": {
-                              "anyOf": [
-                                {
-                                  "anyOf": [
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "a": {
-                                          "type": "string",
-                                          "const": "get-property"
-                                        },
-                                        "name": {
-                                          "type": "string",
-                                          "minLength": 1,
-                                          "maxLength": 60,
-                                          "pattern": "[a-z][\\d_a-z]+",
-                                          "description": "A short name that could be used a key or variable for the step"
-                                        },
-                                        "title": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                                        },
-                                        "description": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/description"
-                                        },
-                                        "motivation": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/motivation"
-                                        },
-                                        "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
-                                        },
-                                        "value": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
-                                        }
+                          "minItems": 1,
+                          "maxItems": 3,
+                          "description": "The same batch will be run multiple times for each loop"
+                        },
+                        "commands": {
+                          "type": "array",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "a": {
+                                        "type": "string",
+                                        "const": "get-property"
                                       },
-                                      "required": [
-                                        "a",
-                                        "name",
-                                        "title",
-                                        "value"
-                                      ],
-                                      "additionalProperties": false,
-                                      "description": "Get a property using a dot prop path"
-                                    },
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "a": {
-                                          "type": "string",
-                                          "const": "string-array"
-                                        },
-                                        "name": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/name"
-                                        },
-                                        "title": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                                        },
-                                        "description": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/description"
-                                        },
-                                        "motivation": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
-                                        },
-                                        "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
-                                        },
-                                        "value": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
-                                        },
-                                        "onSuccess": {
-                                          "type": "string",
-                                          "enum": [
-                                            "sort",
-                                            "unique",
-                                            "filled",
-                                            "reverse"
-                                          ]
-                                        },
-                                        "filters": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "object",
-                                            "properties": {
-                                              "if": {
-                                                "type": "string",
-                                                "enum": [
-                                                  "starts-with",
-                                                  "ends-with",
-                                                  "contains",
-                                                  "equals",
-                                                  "not starts-with",
-                                                  "not ends-with",
-                                                  "not contains",
-                                                  "not equals"
-                                                ],
-                                                "description": "Filter criteria"
-                                              },
-                                              "anyOf": {
-                                                "type": "array",
-                                                "items": {
-                                                  "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
-                                                },
-                                                "minItems": 1,
-                                                "maxItems": 50,
-                                                "description": "A list of references to match against"
-                                              }
-                                            },
-                                            "required": [
-                                              "if",
-                                              "anyOf"
-                                            ],
-                                            "additionalProperties": false,
-                                            "description": "Filter an array of strings"
-                                          },
-                                          "minItems": 1,
-                                          "maxItems": 20,
-                                          "description": "A list of filters on strings"
-                                        }
+                                      "name": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "maxLength": 60,
+                                        "pattern": "[a-z][\\d_a-z]+",
+                                        "description": "A short name that could be used a key or variable for the step"
                                       },
-                                      "required": [
-                                        "a",
-                                        "name",
-                                        "title",
-                                        "value",
-                                        "onSuccess"
-                                      ],
-                                      "additionalProperties": false,
-                                      "description": "Process on a list of strings"
-                                    },
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "a": {
-                                          "type": "string",
-                                          "const": "concat-array"
-                                        },
-                                        "name": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/name"
-                                        },
-                                        "title": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                                        },
-                                        "description": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/description"
-                                        },
-                                        "motivation": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
-                                        },
-                                        "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
-                                        },
-                                        "values": {
-                                          "type": "array",
-                                          "items": {
-                                            "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
-                                          },
-                                          "minItems": 1,
-                                          "maxItems": 20
-                                        }
+                                      "title": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
                                       },
-                                      "required": [
-                                        "a",
-                                        "name",
-                                        "title",
-                                        "values"
-                                      ],
-                                      "additionalProperties": false,
-                                      "description": "Concatenate several arrays together"
-                                    },
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "a": {
-                                          "type": "string",
-                                          "const": "split-string"
-                                        },
-                                        "name": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/name"
-                                        },
-                                        "title": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                                        },
-                                        "description": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/description"
-                                        },
-                                        "motivation": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
-                                        },
-                                        "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
-                                        },
-                                        "separator": {
-                                          "type": "string",
-                                          "minLength": 1,
-                                          "maxLength": 80,
-                                          "default": " ",
-                                          "description": "A separator to split the string"
-                                        },
-                                        "value": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
-                                        }
+                                      "description": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/description"
                                       },
-                                      "required": [
-                                        "a",
-                                        "name",
-                                        "title",
-                                        "value"
-                                      ],
-                                      "additionalProperties": false,
-                                      "description": "Split a string into multiple strings"
-                                    },
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "a": {
-                                          "type": "string",
-                                          "const": "some-truthy"
-                                        },
-                                        "name": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/name"
-                                        },
-                                        "title": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                                        },
-                                        "description": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/description"
-                                        },
-                                        "motivation": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
-                                        },
-                                        "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
-                                        },
-                                        "values": {
-                                          "type": "array",
-                                          "items": {
-                                            "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
-                                          },
-                                          "minItems": 1,
-                                          "maxItems": 20
-                                        }
+                                      "motivation": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/motivation"
                                       },
-                                      "required": [
-                                        "a",
-                                        "name",
-                                        "title",
-                                        "values"
-                                      ],
-                                      "additionalProperties": false,
-                                      "description": "Return true if at least one of values is truthy"
-                                    },
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "a": {
-                                          "type": "string",
-                                          "const": "some-falsy"
-                                        },
-                                        "name": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/name"
-                                        },
-                                        "title": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                                        },
-                                        "description": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/description"
-                                        },
-                                        "motivation": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
-                                        },
-                                        "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
-                                        },
-                                        "values": {
-                                          "type": "array",
-                                          "items": {
-                                            "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
-                                          },
-                                          "minItems": 1,
-                                          "maxItems": 20
-                                        }
+                                      "links": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                       },
-                                      "required": [
-                                        "a",
-                                        "name",
-                                        "title",
-                                        "values"
-                                      ],
-                                      "additionalProperties": false,
-                                      "description": "Return true if at least one of values is falsy"
+                                      "value": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/if"
+                                      }
                                     },
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "a": {
-                                          "type": "string",
-                                          "const": "every-truthy"
-                                        },
-                                        "name": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/name"
-                                        },
-                                        "title": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                                        },
-                                        "description": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/description"
-                                        },
-                                        "motivation": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
-                                        },
-                                        "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
-                                        },
-                                        "values": {
-                                          "type": "array",
-                                          "items": {
-                                            "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
-                                          },
-                                          "minItems": 1,
-                                          "maxItems": 20
-                                        }
+                                    "required": [
+                                      "a",
+                                      "name",
+                                      "title",
+                                      "value"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Get a property using a dot prop path"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "a": {
+                                        "type": "string",
+                                        "const": "string-array"
                                       },
-                                      "required": [
-                                        "a",
-                                        "name",
-                                        "title",
-                                        "values"
-                                      ],
-                                      "additionalProperties": false,
-                                      "description": "Return true if all the values are truthy"
-                                    },
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "a": {
-                                          "type": "string",
-                                          "const": "every-falsy"
-                                        },
-                                        "name": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/name"
-                                        },
-                                        "title": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                                        },
-                                        "description": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/description"
-                                        },
-                                        "motivation": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
-                                        },
-                                        "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
-                                        },
-                                        "values": {
-                                          "type": "array",
-                                          "items": {
-                                            "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
-                                          },
-                                          "minItems": 1,
-                                          "maxItems": 20
-                                        }
+                                      "name": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/name"
                                       },
-                                      "required": [
-                                        "a",
-                                        "name",
-                                        "title",
-                                        "values"
-                                      ],
-                                      "additionalProperties": false,
-                                      "description": "Return true if all the values are falsy"
-                                    },
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "a": {
-                                          "type": "string",
-                                          "const": "not"
-                                        },
-                                        "name": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/name"
-                                        },
-                                        "title": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                                        },
-                                        "description": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/description"
-                                        },
-                                        "motivation": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
-                                        },
-                                        "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
-                                        },
-                                        "value": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
-                                        }
+                                      "title": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
                                       },
-                                      "required": [
-                                        "a",
-                                        "name",
-                                        "title",
-                                        "value"
-                                      ],
-                                      "additionalProperties": false,
-                                      "description": "Return the opposite boolean value"
-                                    },
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "a": {
-                                          "type": "string",
-                                          "const": "range"
-                                        },
-                                        "name": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/name"
-                                        },
-                                        "title": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                                        },
-                                        "description": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/description"
-                                        },
-                                        "motivation": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
-                                        },
-                                        "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
-                                        },
-                                        "start": {
-                                          "type": "integer",
-                                          "default": 0,
-                                          "description": "The number to start the range with"
-                                        },
-                                        "end": {
-                                          "type": "integer",
-                                          "description": "The number at the end of the range"
-                                        },
-                                        "step": {
-                                          "type": "integer",
-                                          "default": 1,
-                                          "description": "A step to increment the range, usually 1"
-                                        }
+                                      "description": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/description"
                                       },
-                                      "required": [
-                                        "a",
-                                        "name",
-                                        "title",
-                                        "end"
-                                      ],
-                                      "additionalProperties": false,
-                                      "description": "Generate a range of numbers"
-                                    },
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "a": {
-                                          "type": "string",
-                                          "const": "invert-object"
-                                        },
-                                        "name": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/name"
-                                        },
-                                        "title": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                                        },
-                                        "description": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/description"
-                                        },
-                                        "motivation": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
-                                        },
-                                        "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
-                                        },
-                                        "value": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
-                                        }
+                                      "motivation": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
                                       },
-                                      "required": [
-                                        "a",
-                                        "name",
-                                        "title",
-                                        "value"
-                                      ],
-                                      "additionalProperties": false,
-                                      "description": "Invert keys and values into a new object"
-                                    },
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "a": {
-                                          "type": "string",
-                                          "const": "mask-object"
-                                        },
-                                        "name": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/name"
-                                        },
-                                        "title": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                                        },
-                                        "description": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/description"
-                                        },
-                                        "motivation": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
-                                        },
-                                        "links": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
-                                        },
-                                        "value": {
-                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if"
-                                        },
-                                        "mask": {
-                                          "type": "string",
-                                          "minLength": 1,
-                                          "maxLength": 100,
-                                          "description": "JSON mask to select parts of the json object"
-                                        }
+                                      "links": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
                                       },
-                                      "required": [
-                                        "a",
-                                        "name",
-                                        "title",
-                                        "value",
-                                        "mask"
-                                      ],
-                                      "additionalProperties": false,
-                                      "description": "Uses JSON mask to select parts of the json object"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 60,
-                                      "pattern": "[a-z][\\d_a-z]+",
-                                      "description": "A short name that could be used a key or variable"
-                                    },
-                                    "title": {
-                                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
-                                    },
-                                    "description": {
-                                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/description"
-                                    },
-                                    "motivation": {
-                                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/motivation"
-                                    },
-                                    "links": {
-                                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
-                                    },
-                                    "a": {
-                                      "type": "string",
-                                      "const": "shell",
-                                      "default": "shell"
-                                    },
-                                    "onFailure": {
-                                      "type": "array",
-                                      "items": {
+                                      "value": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/if"
+                                      },
+                                      "onSuccess": {
                                         "type": "string",
                                         "enum": [
-                                          "exit",
-                                          "silent",
-                                          "trim",
-                                          "json",
-                                          "yaml",
-                                          "csv",
-                                          "save",
-                                          "debug"
+                                          "sort",
+                                          "unique",
+                                          "filled",
+                                          "reverse"
                                         ]
                                       },
-                                      "minItems": 1,
-                                      "default": [
-                                        "exit"
-                                      ],
-                                      "description": "List of flags to describe the default behavior in case of failure"
+                                      "filters": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "if": {
+                                              "type": "string",
+                                              "enum": [
+                                                "starts-with",
+                                                "ends-with",
+                                                "contains",
+                                                "equals",
+                                                "not starts-with",
+                                                "not ends-with",
+                                                "not contains",
+                                                "not equals"
+                                              ],
+                                              "description": "Filter criteria"
+                                            },
+                                            "anyOf": {
+                                              "type": "array",
+                                              "items": {
+                                                "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/if"
+                                              },
+                                              "minItems": 1,
+                                              "maxItems": 50,
+                                              "description": "A list of references to match against"
+                                            }
+                                          },
+                                          "required": [
+                                            "if",
+                                            "anyOf"
+                                          ],
+                                          "additionalProperties": false,
+                                          "description": "Filter an array of strings"
+                                        },
+                                        "minItems": 1,
+                                        "maxItems": 20,
+                                        "description": "A list of filters on strings"
+                                      }
                                     },
-                                    "onSuccess": {
-                                      "type": "array",
-                                      "items": {
-                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/commands/items/anyOf/1/properties/onFailure/items"
-                                      },
-                                      "minItems": 1,
-                                      "default": [
-                                        "trim"
-                                      ],
-                                      "description": "List of flags to describe the default behavior in case of success"
-                                    },
-                                    "if": {
-                                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if",
-                                      "description": "reference to JSON path that must be satisfied for the step to run"
-                                    },
-                                    "stdin": {
-                                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps/items/properties/if",
-                                      "description": "Provide stdin with a value read from a dot prop path"
-                                    },
-                                    "run": {
-                                      "type": "string",
-                                      "minLength": 1,
-                                      "maxLength": 300,
-                                      "description": "A line of shell script"
-                                    }
+                                    "required": [
+                                      "a",
+                                      "name",
+                                      "title",
+                                      "value",
+                                      "onSuccess"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Process on a list of strings"
                                   },
-                                  "required": [
-                                    "title",
-                                    "run"
-                                  ],
-                                  "additionalProperties": false,
-                                  "description": "Configuration for the batch shell script"
-                                }
-                              ],
-                              "description": "A command to be run"
-                            },
-                            "minItems": 1,
-                            "maxItems": 50,
-                            "description": "A list of batch shell scripts to run"
-                          }
-                        },
-                        "required": [
-                          "commands"
-                        ],
-                        "additionalProperties": false,
-                        "description": "A batch of shell commands to run"
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "a": {
+                                        "type": "string",
+                                        "const": "concat-array"
+                                      },
+                                      "name": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/name"
+                                      },
+                                      "title": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
+                                      },
+                                      "description": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/description"
+                                      },
+                                      "motivation": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
+                                      },
+                                      "links": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
+                                      },
+                                      "values": {
+                                        "type": "array",
+                                        "items": {
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/if"
+                                        },
+                                        "minItems": 1,
+                                        "maxItems": 20
+                                      }
+                                    },
+                                    "required": [
+                                      "a",
+                                      "name",
+                                      "title",
+                                      "values"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Concatenate several arrays together"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "a": {
+                                        "type": "string",
+                                        "const": "split-string"
+                                      },
+                                      "name": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/name"
+                                      },
+                                      "title": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
+                                      },
+                                      "description": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/description"
+                                      },
+                                      "motivation": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
+                                      },
+                                      "links": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
+                                      },
+                                      "separator": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "maxLength": 80,
+                                        "default": " ",
+                                        "description": "A separator to split the string"
+                                      },
+                                      "value": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/if"
+                                      }
+                                    },
+                                    "required": [
+                                      "a",
+                                      "name",
+                                      "title",
+                                      "value"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Split a string into multiple strings"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "a": {
+                                        "type": "string",
+                                        "const": "some-truthy"
+                                      },
+                                      "name": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/name"
+                                      },
+                                      "title": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
+                                      },
+                                      "description": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/description"
+                                      },
+                                      "motivation": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
+                                      },
+                                      "links": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
+                                      },
+                                      "values": {
+                                        "type": "array",
+                                        "items": {
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/if"
+                                        },
+                                        "minItems": 1,
+                                        "maxItems": 20
+                                      }
+                                    },
+                                    "required": [
+                                      "a",
+                                      "name",
+                                      "title",
+                                      "values"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Return true if at least one of values is truthy"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "a": {
+                                        "type": "string",
+                                        "const": "some-falsy"
+                                      },
+                                      "name": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/name"
+                                      },
+                                      "title": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
+                                      },
+                                      "description": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/description"
+                                      },
+                                      "motivation": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
+                                      },
+                                      "links": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
+                                      },
+                                      "values": {
+                                        "type": "array",
+                                        "items": {
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/if"
+                                        },
+                                        "minItems": 1,
+                                        "maxItems": 20
+                                      }
+                                    },
+                                    "required": [
+                                      "a",
+                                      "name",
+                                      "title",
+                                      "values"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Return true if at least one of values is falsy"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "a": {
+                                        "type": "string",
+                                        "const": "every-truthy"
+                                      },
+                                      "name": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/name"
+                                      },
+                                      "title": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
+                                      },
+                                      "description": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/description"
+                                      },
+                                      "motivation": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
+                                      },
+                                      "links": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
+                                      },
+                                      "values": {
+                                        "type": "array",
+                                        "items": {
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/if"
+                                        },
+                                        "minItems": 1,
+                                        "maxItems": 20
+                                      }
+                                    },
+                                    "required": [
+                                      "a",
+                                      "name",
+                                      "title",
+                                      "values"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Return true if all the values are truthy"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "a": {
+                                        "type": "string",
+                                        "const": "every-falsy"
+                                      },
+                                      "name": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/name"
+                                      },
+                                      "title": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
+                                      },
+                                      "description": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/description"
+                                      },
+                                      "motivation": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
+                                      },
+                                      "links": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
+                                      },
+                                      "values": {
+                                        "type": "array",
+                                        "items": {
+                                          "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/if"
+                                        },
+                                        "minItems": 1,
+                                        "maxItems": 20
+                                      }
+                                    },
+                                    "required": [
+                                      "a",
+                                      "name",
+                                      "title",
+                                      "values"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Return true if all the values are falsy"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "a": {
+                                        "type": "string",
+                                        "const": "not"
+                                      },
+                                      "name": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/name"
+                                      },
+                                      "title": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
+                                      },
+                                      "description": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/description"
+                                      },
+                                      "motivation": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
+                                      },
+                                      "links": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
+                                      },
+                                      "value": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/if"
+                                      }
+                                    },
+                                    "required": [
+                                      "a",
+                                      "name",
+                                      "title",
+                                      "value"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Return the opposite boolean value"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "a": {
+                                        "type": "string",
+                                        "const": "range"
+                                      },
+                                      "name": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/name"
+                                      },
+                                      "title": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
+                                      },
+                                      "description": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/description"
+                                      },
+                                      "motivation": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
+                                      },
+                                      "links": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
+                                      },
+                                      "start": {
+                                        "type": "integer",
+                                        "default": 0,
+                                        "description": "The number to start the range with"
+                                      },
+                                      "end": {
+                                        "type": "integer",
+                                        "description": "The number at the end of the range"
+                                      },
+                                      "step": {
+                                        "type": "integer",
+                                        "default": 1,
+                                        "description": "A step to increment the range, usually 1"
+                                      }
+                                    },
+                                    "required": [
+                                      "a",
+                                      "name",
+                                      "title",
+                                      "end"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Generate a range of numbers"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "a": {
+                                        "type": "string",
+                                        "const": "invert-object"
+                                      },
+                                      "name": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/name"
+                                      },
+                                      "title": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
+                                      },
+                                      "description": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/description"
+                                      },
+                                      "motivation": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
+                                      },
+                                      "links": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
+                                      },
+                                      "value": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/if"
+                                      }
+                                    },
+                                    "required": [
+                                      "a",
+                                      "name",
+                                      "title",
+                                      "value"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Invert keys and values into a new object"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "a": {
+                                        "type": "string",
+                                        "const": "mask-object"
+                                      },
+                                      "name": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/name"
+                                      },
+                                      "title": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
+                                      },
+                                      "description": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/description"
+                                      },
+                                      "motivation": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/0/anyOf/0/properties/motivation"
+                                      },
+                                      "links": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
+                                      },
+                                      "value": {
+                                        "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/if"
+                                      },
+                                      "mask": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "maxLength": 100,
+                                        "description": "JSON mask to select parts of the json object"
+                                      }
+                                    },
+                                    "required": [
+                                      "a",
+                                      "name",
+                                      "title",
+                                      "value",
+                                      "mask"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Uses JSON mask to select parts of the json object"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 60,
+                                    "pattern": "[a-z][\\d_a-z]+",
+                                    "description": "A short name that could be used a key or variable"
+                                  },
+                                  "title": {
+                                    "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/title"
+                                  },
+                                  "description": {
+                                    "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/description"
+                                  },
+                                  "motivation": {
+                                    "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/motivation"
+                                  },
+                                  "links": {
+                                    "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/links"
+                                  },
+                                  "a": {
+                                    "type": "string",
+                                    "const": "shell",
+                                    "default": "shell"
+                                  },
+                                  "onFailure": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string",
+                                      "enum": [
+                                        "exit",
+                                        "silent",
+                                        "trim",
+                                        "json",
+                                        "yaml",
+                                        "csv",
+                                        "save",
+                                        "debug"
+                                      ]
+                                    },
+                                    "minItems": 1,
+                                    "default": [
+                                      "exit"
+                                    ],
+                                    "description": "List of flags to describe the default behavior in case of failure"
+                                  },
+                                  "onSuccess": {
+                                    "type": "array",
+                                    "items": {
+                                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/commands/items/anyOf/1/properties/onFailure/items"
+                                    },
+                                    "minItems": 1,
+                                    "default": [
+                                      "trim"
+                                    ],
+                                    "description": "List of flags to describe the default behavior in case of success"
+                                  },
+                                  "if": {
+                                    "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/if",
+                                    "description": "reference to JSON path that must be satisfied for the step to run"
+                                  },
+                                  "stdin": {
+                                    "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main/properties/if",
+                                    "description": "Provide stdin with a value read from a dot prop path"
+                                  },
+                                  "run": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 300,
+                                    "description": "A line of shell script"
+                                  }
+                                },
+                                "required": [
+                                  "title",
+                                  "run"
+                                ],
+                                "additionalProperties": false,
+                                "description": "Configuration for the batch shell script"
+                              }
+                            ],
+                            "description": "A command to be run"
+                          },
+                          "minItems": 1,
+                          "maxItems": 50,
+                          "description": "A list of batch shell scripts to run"
+                        }
                       },
-                      "minItems": 1
+                      "required": [
+                        "commands"
+                      ],
+                      "additionalProperties": false,
+                      "description": "A batch of shell commands to run"
+                    },
+                    "before": {
+                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main"
+                    },
+                    "after": {
+                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main"
                     },
                     "finally": {
-                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/steps"
+                      "$ref": "#/definitions/baldrick-broth-schema/properties/workflows/additionalProperties/properties/tasks/additionalProperties/properties/main"
                     }
                   },
                   "required": [
                     "title",
-                    "steps"
+                    "main"
                   ],
                   "additionalProperties": false,
                   "description": "Settings for a task"

--- a/spec/snapshots/build-model/safe-parse-build--abstract-parsing.yaml
+++ b/spec/snapshots/build-model/safe-parse-build--abstract-parsing.yaml
@@ -39,7 +39,11 @@ abstract:
     kind: string
   - path: value.workflows.test.tasks.generate.parameters
     kind: array/object
-  - path: value.workflows.test.tasks.generate.steps
+  - path: value.workflows.test.tasks.generate.main.name
+    kind: string
+  - path: value.workflows.test.tasks.generate.main.commands
     kind: array/object
-  - path: value.workflows.test.tasks.generate.finally
+  - path: value.workflows.test.tasks.generate.finally.name
+    kind: string
+  - path: value.workflows.test.tasks.generate.finally.commands
     kind: array/object

--- a/spec/snapshots/build-model/safe-parse-build--abstract-parsing.yaml
+++ b/spec/snapshots/build-model/safe-parse-build--abstract-parsing.yaml
@@ -43,7 +43,7 @@ abstract:
     kind: string
   - path: value.workflows.test.tasks.generate.main.commands
     kind: array/object
-  - path: value.workflows.test.tasks.generate.finally.name
+  - path: value.workflows.test.tasks.generate.after.name
     kind: string
-  - path: value.workflows.test.tasks.generate.finally.commands
+  - path: value.workflows.test.tasks.generate.after.commands
     kind: array/object

--- a/spec/snapshots/build-model/safe-parse-build--invalid-too-large.yaml
+++ b/spec/snapshots/build-model/safe-parse-build--invalid-too-large.yaml
@@ -14,7 +14,7 @@
           300
 - title: "Path: model.githubAccount, mutation: string => large"
   result:
-    count: "Words: 180, Characters 102650"
+    count: "Words: 176, Characters 102519"
 - title: "Path: workflows.test.title, mutation: string => large"
   result:
     status: failure

--- a/spec/snapshots/build-model/safe-parse-build--invalid-too-large.yaml
+++ b/spec/snapshots/build-model/safe-parse-build--invalid-too-large.yaml
@@ -14,7 +14,7 @@
           300
 - title: "Path: model.githubAccount, mutation: string => large"
   result:
-    count: "Words: 176, Characters 102519"
+    count: "Words: 176, Characters 102517"
 - title: "Path: workflows.test.title, mutation: string => large"
   result:
     status: failure

--- a/spec/snapshots/build-model/safe-parse-build--invalid-too-large.yaml
+++ b/spec/snapshots/build-model/safe-parse-build--invalid-too-large.yaml
@@ -14,7 +14,7 @@
           300
 - title: "Path: model.githubAccount, mutation: string => large"
   result:
-    count: "Words: 190, Characters 102749"
+    count: "Words: 180, Characters 102650"
 - title: "Path: workflows.test.title, mutation: string => large"
   result:
     status: failure

--- a/src/build-model.ts
+++ b/src/build-model.ts
@@ -318,7 +318,6 @@ const task = z
     main: batchStep,
     before: batchStep.optional(),
     after: batchStep.optional(),
-    finally: batchStep.optional(),
   })
   .describe('Settings for a task');
 const domain = z

--- a/src/build-model.ts
+++ b/src/build-model.ts
@@ -287,7 +287,7 @@ const commands = z
 
 const batchStep = z
   .strictObject({
-    name: z.enum(['main', 'before', 'after']).default('main'),
+    name: z.enum(['unknown', 'main', 'before', 'after']).default('unknown'),
     if: stringy.varValue
       .optional()
       .describe('A condition that must be satisfied to enable the batch'),
@@ -300,7 +300,6 @@ const batchStep = z
     commands,
   })
   .describe('A batch of shell commands to run');
-const steps = z.array(batchStep).min(1);
 const parameter = z
   .object({
     description: stringy.description,
@@ -316,8 +315,10 @@ const task = z
     motivation: stringy.motivation.optional(),
     links,
     parameters: z.array(parameter).max(20).optional(),
-    steps,
-    finally: steps.optional(),
+    main: batchStep,
+    before: batchStep.optional(),
+    after: batchStep.optional(),
+    finally: batchStep.optional(),
   })
   .describe('Settings for a task');
 const domain = z

--- a/src/build-model.ts
+++ b/src/build-model.ts
@@ -24,7 +24,6 @@ const engine = z
   })
   .optional()
   .describe('Settings for the baldrick-broth engine');
-const onBatchStepFinish = z.enum(['exit', 'silent']);
 
 const onShellCommandFinish = z.enum([
   'exit',
@@ -288,8 +287,7 @@ const commands = z
 
 const batchStep = z
   .strictObject({
-    a: z.literal('batch'),
-    ...metadataCore,
+    name: z.enum(['main', 'before', 'after']).default('main'),
     if: stringy.varValue
       .optional()
       .describe('A condition that must be satisfied to enable the batch'),
@@ -299,11 +297,6 @@ const batchStep = z
       .max(3)
       .optional()
       .describe('The same batch will be run multiple times for each loop'),
-    onFinish: z
-      .array(onBatchStepFinish)
-      .min(1)
-      .optional()
-      .describe('Expected behavior when the batch finishes'),
     commands,
   })
   .describe('A batch of shell commands to run');
@@ -321,6 +314,7 @@ const task = z
     title: stringy.title,
     description: stringy.description.optional(),
     motivation: stringy.motivation.optional(),
+    links,
     parameters: z.array(parameter).max(20).optional(),
     steps,
     finally: steps.optional(),

--- a/src/coloration.ts
+++ b/src/coloration.ts
@@ -17,4 +17,7 @@ export const coloration = {
   get actual() {
     return chalk.redBright;
   },
+  get title() {
+    return chalk.blueBright;
+  },
 };

--- a/src/coloration.ts
+++ b/src/coloration.ts
@@ -17,7 +17,10 @@ export const coloration = {
   get actual() {
     return chalk.redBright;
   },
-  get title() {
-    return chalk.blueBright;
+  get taskTitle() {
+    return chalk.hex('#800080').bold.underline;
+  },
+  get stepTitle() {
+    return chalk.hex('#4B0082');
   },
 };

--- a/src/commands-creator.ts
+++ b/src/commands-creator.ts
@@ -45,6 +45,13 @@ export const createCommands = (
         }
         const taskCommand = workflowCmd.command(taskId);
         taskCommand.summary(task.title);
+        task.main.name = 'main';
+        if (task.before) {
+          task.before.name = 'before';
+        }
+        if (task.after) {
+          task.after.name = 'after';
+        }
         taskCommand.description(createTaskDescription(task));
         taskCommand.action(
           createTaskAction({

--- a/src/create-task-action.ts
+++ b/src/create-task-action.ts
@@ -107,7 +107,7 @@ const toCommandLineAction = (
             cmdLineResult.value.format === 'string'
               ? data
               : JSON.stringify(data, null, 2);
-          currentTaskLogger.info(coloration.title(title))
+          currentTaskLogger.info(coloration.stepTitle(`◼ ${title}`));
           currentTaskLogger.info(dataView);
         }
         if (successFlags.debug) {
@@ -185,6 +185,8 @@ export const createTaskAction =
       },
       parameters,
     };
+    currentTaskLogger.info(coloration.taskTitle(buildCtx.task.title));
+
     const ctx: Ctx = { ...buildCtx, runtime, data: { status: 'created' } };
     const started = process.hrtime();
     const task = ctx.task;
@@ -193,7 +195,7 @@ export const createTaskAction =
       const beforeStep = toBatchStepAction(ctx, task.before);
       if (beforeStep.status === 'failure') {
         currentTaskLogger.error(
-          makeMessage(`Before ${projectName}`, beforeStep.error.messages)
+          makeMessage(`Before ${buildCtx.task.name}`, beforeStep.error.messages)
         );
       } else {
         listTasks.push(beforeStep.value);
@@ -203,7 +205,7 @@ export const createTaskAction =
     const mainStep = toBatchStepAction(ctx, task.main);
     if (mainStep.status === 'failure') {
       currentTaskLogger.error(
-        makeMessage(`Main ${projectName}`, mainStep.error.messages)
+        makeMessage(`Main ${buildCtx.task.name}`, mainStep.error.messages)
       );
     } else {
       listTasks.push(mainStep.value);
@@ -213,7 +215,7 @@ export const createTaskAction =
       const afterStep = toBatchStepAction(ctx, task.after);
       if (afterStep.status === 'failure') {
         currentTaskLogger.error(
-          makeMessage(`After ${projectName}`, afterStep.error.messages)
+          makeMessage(`After ${buildCtx.task.name}`, afterStep.error.messages)
         );
       } else {
         listTasks.push(afterStep.value);

--- a/src/create-task-action.ts
+++ b/src/create-task-action.ts
@@ -35,10 +35,6 @@ function sleep(ms: number) {
   });
 }
 
-const startStepTitle = (batchStep: BatchStepModel): string => {
-  const underline = '-'.repeat(batchStep.title.length + 1);
-  return `${batchStep.title}:\n${underline}`;
-};
 const mergeBatchStepAction = (stepActions: BatchStepAction[]): BatchAction => {
   const withErrors = stepActions.filter((i) => i.status === 'failure');
   if (withErrors.length > 0) {
@@ -160,7 +156,7 @@ const toBatchStepAction = (
   ctx: Ctx,
   batchStep: BatchStepModel
 ): BatchStepAction => {
-  const title = batchStep.title ? batchStep.title : batchStep.name;
+  const title = `${batchStep.name} step`;
 
   const batchTask: ListrTask = {
     title,
@@ -174,7 +170,6 @@ const toBatchStepAction = (
         const commandTasks = commandsForStep.value.map((input) =>
           toCommandLineAction(ctx, input)
         );
-        currentTaskLogger.info(startStepTitle(batchStep));
         return task.newListr([...commandTasks], { exitOnError: false });
       } else {
         return;

--- a/src/create-task-action.ts
+++ b/src/create-task-action.ts
@@ -163,6 +163,9 @@ const toBatchStepAction = (
   return succeed(batchTask);
 };
 
+const makeMessage = (title: string, messages: string[]): string =>
+  `${title}: ${messages.join('\n')}`;
+
 type BuildCtx = Pick<Ctx, 'build' | 'task'>;
 export const createTaskAction =
   (buildCtx: BuildCtx) =>
@@ -185,7 +188,9 @@ export const createTaskAction =
     if (task.before !== undefined) {
       const beforeStep = toBatchStepAction(ctx, task.before);
       if (beforeStep.status === 'failure') {
-        console.log('Failure before', beforeStep.error.messages);
+        currentTaskLogger.error(
+          makeMessage(`Before ${projectName}`, beforeStep.error.messages)
+        );
       } else {
         listTasks.push(beforeStep.value);
       }
@@ -193,7 +198,9 @@ export const createTaskAction =
 
     const mainStep = toBatchStepAction(ctx, task.main);
     if (mainStep.status === 'failure') {
-      console.log('Failure main', mainStep.error.messages);
+      currentTaskLogger.error(
+        makeMessage(`Main ${projectName}`, mainStep.error.messages)
+      );
     } else {
       listTasks.push(mainStep.value);
     }
@@ -201,7 +208,9 @@ export const createTaskAction =
     if (task.after !== undefined) {
       const afterStep = toBatchStepAction(ctx, task.after);
       if (afterStep.status === 'failure') {
-        console.log('Failure after', afterStep.error.messages);
+        currentTaskLogger.error(
+          makeMessage(`After ${projectName}`, afterStep.error.messages)
+        );
       } else {
         listTasks.push(afterStep.value);
       }
@@ -216,7 +225,7 @@ export const createTaskAction =
         logTaskStatistics(started, ctx);
         await replayLogToConsole();
       } catch (error: any) {
-        console.log('Failure', error);
+        currentTaskLogger.error(error);
       }
     }
   };

--- a/src/create-task-action.ts
+++ b/src/create-task-action.ts
@@ -136,11 +136,14 @@ const toCommandLineAction = (
   return commandTask;
 };
 
+const capitalizeWord = (text: string): string =>
+  text.length > 0 ? text[0]?.toUpperCase() + text.slice(1).toLowerCase() : '';
+
 const toBatchStepAction = (
   ctx: Ctx,
   batchStep: BatchStepModel
 ): BatchStepAction => {
-  const title = `${batchStep.name} step`;
+  const title = capitalizeWord(batchStep.name);
 
   const batchTask: ListrTask = {
     title,

--- a/src/create-task-action.ts
+++ b/src/create-task-action.ts
@@ -107,6 +107,7 @@ const toCommandLineAction = (
             cmdLineResult.value.format === 'string'
               ? data
               : JSON.stringify(data, null, 2);
+          currentTaskLogger.info(coloration.title(title))
           currentTaskLogger.info(dataView);
         }
         if (successFlags.debug) {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -172,8 +172,21 @@ const executeShellCommandLine = async (
     maybeStdin = {};
   }
 
-  const { stdout, stderr, all, exitCode, failed, isCanceled, timedOut, killed } =
-    await execaCommand(line, { reject: false, all: true, env: { FORCE_COLOR: 'true'}, ...maybeStdin });
+  const {
+    stdout,
+    stderr,
+    all,
+    exitCode,
+    failed,
+    isCanceled,
+    timedOut,
+    killed,
+  } = await execaCommand(line, {
+    reject: false,
+    all: true,
+    env: { FORCE_COLOR: 'true' },
+    ...maybeStdin,
+  });
 
   const status = toStatus({ exitCode, failed, isCanceled, timedOut, killed });
 
@@ -239,7 +252,9 @@ const executeShellCommandLine = async (
           });
     }
 
-    const data = onSuccess.includes('trim') ? (all || stdout).trim() : (all || stdout);
+    const data = onSuccess.includes('trim')
+      ? (all || stdout).trim()
+      : all || stdout;
 
     return succeed({ format: 'string', name, line, data, onSuccess });
   } else {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -172,8 +172,8 @@ const executeShellCommandLine = async (
     maybeStdin = {};
   }
 
-  const { stdout, stderr, exitCode, failed, isCanceled, timedOut, killed } =
-    await execaCommand(line, { reject: false, ...maybeStdin });
+  const { stdout, stderr, all, exitCode, failed, isCanceled, timedOut, killed } =
+    await execaCommand(line, { reject: false, all: true, env: { FORCE_COLOR: 'true'}, ...maybeStdin });
 
   const status = toStatus({ exitCode, failed, isCanceled, timedOut, killed });
 
@@ -239,7 +239,7 @@ const executeShellCommandLine = async (
           });
     }
 
-    const data = onSuccess.includes('trim') ? stdout.trim() : stdout;
+    const data = onSuccess.includes('trim') ? (all || stdout).trim() : (all || stdout);
 
     return succeed({ format: 'string', name, line, data, onSuccess });
   } else {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.9.0';
+export const version = '0.10.0';


### PR DESCRIPTION
# Summary of the change

- Simplify attributes of a single step
- Use main after and before for task
- add task step name
- Update zest snapshot for safe parse
- force colors
- force colors
- Update snaphot with colors for pest
- Uses logger instead of console.log
- Simple capitalize title
- Log step title
- Color for task and step
- Increment version
- remove finally from model for task as we may never use it

## Code check

-   [x] `npx baldrick-broth@latest release ready` does not show any
    concerning issues

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)

-   [ ] Safe refactoring (non-breaking change which improves the code or
    documentation)

-   [ ] New feature (non-breaking change which adds functionality)

-   [x] Breaking change (fix or feature that would cause existing
    functionality to not work as expected)

## Motivation and context

-   [x] improve user experience
-   [ ] improve consistency
-   [ ] improve security
-   [ ] improve documentation
-   [ ] improve code
-   [ ] reduce risk for unfamiliar tasks
-   [ ] automate repetitive tasks

## How Has This Been Tested

-   [x] Unit tests
-   [ ] Automated browser tests
-   [x] Manual tests
